### PR TITLE
Add ability to ignore unparseable HCL files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pants linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.pants.d
+.pids

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,7 @@
+docker_image(
+    name="hcl-formatter",
+)
+
+shell_sources(
+    name="shell",
+)

--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,70 @@
-COMPOSE_USER=$(shell id -u):$(shell id -g)
+.DEFAULT_GOAL := all
+DOCKER_COMPOSE_RUN := docker compose run --rm --user=$(shell id --user):$(shell id --group)
+DOCKER_BAKE := docker buildx bake
+PANTS_SHELL_FILTER := ./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants
 
-# Linting
+.PHONY: all
+all: format
+all: lint
+all: image
+all: ## Run all operations
+
+.PHONY: help
+help: ## Print this help
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n"} \
+		 /^[a-zA-Z0-9_-]+:.*?##/ { printf "  %-46s %s\n", $$1, $$2 } \
+		 /^##@/ { printf "\n%s\n", substr($$0, 5) } ' \
+		 $(MAKEFILE_LIST)
+	@printf '\n'
+
+##@ Linting
 ########################################################################
-.PHONY: lint
-lint: lint-hcl lint-docker
 
-.PHONY: lint-hcl
-lint-hcl:
-	docker-compose run --rm hcl-linter
+.PHONY: lint
+lint: lint-docker
+lint: lint-hcl
+lint: lint-shell
+lint: ## Perform lint checks on all files
 
 .PHONY: lint-docker
-lint-docker:
-	docker-compose run --rm hadolint
+lint-docker: ## Lint Dockerfile
+	./pants filter --target-type=docker_image :: | xargs ./pants lint
 
-# Formatting
+.PHONY: lint-hcl
+lint-hcl: image # IMPORTANT: run off code from the repository
+lint-hcl: ## Lint HCL files
+	$(DOCKER_COMPOSE_RUN) hcl-linter
+	@echo 🤯 WHOA INCEPTION 🤯
+
+.PHONY: lint-shell
+lint-shell: ## Lint shell scripts
+	$(PANTS_SHELL_FILTER) lint
+
+##@ Formatting
 ########################################################################
+
 .PHONY: format
 format: format-hcl
+format: format-shell
+format: ## Automatically format all code
 
 .PHONY: format-hcl
-format-hcl:
-	docker-compose run --rm --user=${COMPOSE_USER} hcl-formatter
+format-hcl: image # IMPORTANT: run off code from the repository
+format-hcl: ## Format HCL files
+	$(DOCKER_COMPOSE_RUN) hcl-formatter
+	@echo 🤯 WHOA INCEPTION 🤯
 
-# Containers
+.PHONY: format-shell
+format-shell: ## Format shell scripts
+	$(PANTS_SHELL_FILTER) fmt
+
+# Images
 ########################################################################
 
 .PHONY: image
 image:
-	docker buildx bake
+	$(DOCKER_BAKE)
 
 .PHONY: image-push
 image-push:
-	docker buildx bake --push
-
-########################################################################
-
-.PHONY: all
-all: format lint image
+	$(DOCKER_BAKE) --push

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "PACKER_VERSION" {
-  default = "1.7.4"
+  default = "1.8.2"
 }
 
 group "default" {
@@ -11,6 +11,11 @@ target "hcl-formatter" {
   dockerfile = "Dockerfile"
   args = {
     PACKER_VERSION = "${PACKER_VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.authors" = "https://graplsecurity.com"
+    "org.opencontainers.image.source"  = "https://github.com/grapl-security/hcl-formatter",
+    "org.opencontainers.image.vendor"  = "Grapl, Inc."
   }
   tags = [
     "docker.cloudsmith.io/grapl/raw/hcl-formatter:latest",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-common-variables:
   read-only-workdir: &read-only-workdir
     type: bind
@@ -14,20 +12,19 @@ x-common-variables:
 
 services:
   hcl-formatter:
+    # The Makefile will ensure that this image is built from local
+    # sources before invoking this service, so we'll always be
+    # operating off of the code within this repository.
     image: docker.cloudsmith.io/grapl/raw/hcl-formatter:latest
     command: format
     volumes:
       - *read-write-workdir
 
   hcl-linter:
+    # The Makefile will ensure that this image is built from local
+    # sources before invoking this service, so we'll always be
+    # operating off of the code within this repository.
     image: docker.cloudsmith.io/grapl/raw/hcl-formatter:latest
     command: lint
-    volumes:
-      - *read-only-workdir
-
-  hadolint:
-    image: hadolint/hadolint:2.6.0-debian
-    command: [ "hadolint", "Dockerfile" ]
-    working_dir: /workdir
     volumes:
       - *read-only-workdir

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -14,14 +14,78 @@
 
 set -euo pipefail
 
+function usage() {
+    echo "hcl-formatter [--help] [--ignore=FILE]* [ACTION]" >&2
+    echo >&2
+    echo "Options:" >&2
+    echo "    --help              Show this help message" >&2
+    echo "    --ignore            Specify the path of an HCL file that should not be processed." >&2
+    echo "                        Specify the complete literal path within the repository (no wildcards)." >&2
+    echo "                        May be repeated multiple times." >&2
+    echo >&2
+    echo "Actions:" >&2
+    echo "    lint                Check that all files are properly formatted." >&2
+    echo "                        This is the default action if none is otherwise specified." >&2
+    echo "    format              Reformat all files" >&2
+}
+
+# Some files are apparently legal HCL (and can be consumed by Nomad,
+# Consul, etc.) but for some reason are not able to be parsed by
+# Packer's formatter (which is "fine", I guess... we're already
+# abusing Packer here as it is). By specifying these files with an
+# `--ignore` option, we can filter them out, which still allows us to
+# format the bulk of our HCL files.
+ignores=()
+
+while :; do
+    case "${1:-}" in
+        --help)
+            usage
+            exit
+            ;;
+        --ignore)
+            if [ "${2:-}" ]; then
+                ignores+=("${2}")
+                shift
+            else
+                echo "--ignore must have an argument" >&2
+                exit 1
+            fi
+            ;;
+        --ignore=?*)
+            ignores+=("${1#*=}")
+            ;;
+        --ignore=)
+            echo "--ignore cannot have an empty argument" >&2
+            exit 1
+            ;;
+        --)
+            # End of options; stop processing
+            shift
+            break
+            ;;
+        -?*)
+            echo "Found unrecognized option '${1}'" >&2
+            exit 1
+            ;;
+        *)
+            # Found non-option; stop processing
+            break
+            ;;
+    esac
+    shift
+done
+
 readonly command="${1:-lint}"
 
+# We're using an array for `packer_cmd` for quoting / splitting
+# concerns. Yay, Bash!
 case "${command}" in
     lint)
-        packer_cmd="packer fmt -check -diff"
+        packer_cmd=(packer fmt -check -diff)
         ;;
     format)
-        packer_cmd="packer fmt"
+        packer_cmd=(packer fmt)
         ;;
     *)
         echo "Unrecognized command; use 'format' or 'lint'"
@@ -29,8 +93,20 @@ case "${command}" in
         ;;
 esac
 
+########################################################################
+# Now that we've processed the arguments, we need to further process
+# any files that should be ignored in a way that `find` can understand.
+processed_ignores=()
+
+for ignore in "${ignores[@]}"; do
+    processed_ignores+=(\( -not -path "${ignore}" \))
+done
+
+########################################################################
+
 find /workdir \
-     -type f \
-     \( -name "*.nomad" -or -name "*.hcl" \) \
-     -print0 \
-     | xargs -0 -n1 ${packer_cmd}
+    -type f \
+    \( -name "*.nomad" -or -name "*.hcl" \) \
+    "${processed_ignores[@]}" \
+    -print0 |
+    xargs -0 -n1 "${packer_cmd[@]}"

--- a/pants
+++ b/pants
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# =============================== NOTE ===============================
+# This ./pants bootstrap script comes from the pantsbuild/setup
+# project. It is intended to be checked into your code repository so
+# that other developers have the same setup.
+#
+# Learn more here: https://www.pantsbuild.org/docs/installation
+# ====================================================================
+
+set -eou pipefail
+
+# NOTE: To use an unreleased version of Pants from the pantsbuild/pants main branch,
+#  locate the main branch SHA, set PANTS_SHA=<SHA> in the environment, and run this script as usual.
+#
+# E.g., PANTS_SHA=725fdaf504237190f6787dda3d72c39010a4c574 ./pants --version
+
+PYTHON_BIN_NAME="${PYTHON:-unspecified}"
+
+# Set this to specify a non-standard location for this script to read the Pants version from.
+# NB: This will *not* cause Pants itself to use this location as a config file.
+#     You can use PANTS_CONFIG_FILES or --pants-config-files to do so.
+PANTS_TOML=${PANTS_TOML:-pants.toml}
+
+PANTS_BIN_NAME="${PANTS_BIN_NAME:-$0}"
+
+PANTS_SETUP_CACHE="${PANTS_SETUP_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
+# If given a relative path, we fix it to be absolute.
+if [[ "$PANTS_SETUP_CACHE" != /* ]]; then
+  PANTS_SETUP_CACHE="${PWD}/${PANTS_SETUP_CACHE}"
+fi
+
+PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
+
+_PEX_VERSION=2.1.62
+_PEX_URL="https://github.com/pantsbuild/pex/releases/download/v${_PEX_VERSION}/pex"
+_PEX_EXPECTED_SHA256="56668b1ca147bd63141e586ffee97c7cc51ce8e6eac6c9b7a4bf1215b94396e5"
+
+VIRTUALENV_VERSION=20.4.7
+VIRTUALENV_REQUIREMENTS=$(
+cat << EOF
+virtualenv==${VIRTUALENV_VERSION} --hash sha256:2b0126166ea7c9c3661f5b8e06773d28f83322de7a3ff7d06f0aed18c9de6a76
+filelock==3.0.12 --hash sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836
+six==1.16.0 --hash sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+distlib==0.3.2 --hash sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c
+appdirs==1.4.4 --hash sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
+importlib-resources==5.1.4; python_version < "3.7" --hash sha256:e962bff7440364183203d179d7ae9ad90cb1f2b74dcb84300e88ecc42dca3351
+importlib-metadata==4.5.0; python_version < "3.8" --hash sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00
+zipp==3.4.1; python_version < "3.10" --hash sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098
+typing-extensions==3.10.0.0; python_version < "3.8" --hash sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
+EOF
+)
+
+COLOR_RED="\x1b[31m"
+COLOR_GREEN="\x1b[32m"
+COLOR_YELLOW="\x1b[33m"
+COLOR_RESET="\x1b[0m"
+
+function log() {
+  echo -e "$@" 1>&2
+}
+
+function die() {
+  (($# > 0)) && log "${COLOR_RED}$*${COLOR_RESET}"
+  exit 1
+}
+
+function green() {
+  (($# > 0)) && log "${COLOR_GREEN}$*${COLOR_RESET}"
+}
+
+function warn() {
+  (($# > 0)) && log "${COLOR_YELLOW}$*${COLOR_RESET}"
+}
+
+function tempdir {
+  mkdir -p "$1"
+  mktemp -d "$1"/pants.XXXXXX
+}
+
+function get_exe_path_or_die {
+  local exe="$1"
+  if ! command -v "${exe}"; then
+    die "Could not find ${exe}. Please ensure ${exe} is on your PATH."
+  fi
+}
+
+function get_pants_config_string_value {
+  local config_key="$1"
+  local optional_space="[[:space:]]*"
+  local prefix="^${config_key}${optional_space}=${optional_space}"
+  local raw_value
+  raw_value="$(sed -ne "/${prefix}/ s|${prefix}||p" "${PANTS_TOML}")"
+  local optional_suffix="${optional_space}(#.*)?$"
+  echo "${raw_value}" \
+    | sed -E \
+      -e "s|^'([^']*)'${optional_suffix}|\1|" \
+      -e 's|^"([^"]*)"'"${optional_suffix}"'$|\1|' \
+    && return 0
+  return 0
+}
+
+function get_python_major_minor_version {
+  local python_exe="$1"
+  "$python_exe" <<EOF
+import sys
+major_minor_version = ''.join(str(version_num) for version_num in sys.version_info[0:2])
+print(major_minor_version)
+EOF
+}
+
+# The high-level flow:
+#
+# 1.) Resolve the Pants version from config so that we know what interpreters we can use, what to name the venv,
+#     and what to install via pip.
+# 2.) Resolve the Python interpreter, first reading from the env var $PYTHON, then using a default based on the Pants
+#     version.
+# 3.) Check if the venv already exists via a naming convention, and create the venv if not found.
+# 4.) Execute Pants with the resolved Python interpreter and venv.
+#
+# After that, Pants itself will handle making sure any requested plugins
+# are installed and up to date.
+
+function determine_pants_version {
+  if [ -n "${PANTS_SHA:-}" ]; then
+    # get_version_for_sha will echo the version, thus "returning" it from this function.
+    get_version_for_sha "$PANTS_SHA"
+    return
+  fi
+
+  pants_version="$(get_pants_config_string_value 'pants_version')"
+  if [[ -z "${pants_version}" ]]; then
+    die "Please explicitly specify the \`pants_version\` in your \`pants.toml\` under the \`[GLOBAL]\` scope.
+See https://pypi.org/project/pantsbuild.pants/#history for all released versions
+and https://www.pantsbuild.org/docs/installation for more instructions."
+  fi
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  # 1.26 is the first version to support `pants.toml`, so we fail eagerly if using an outdated version.
+  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 25 ]]; then
+    die "This version of the \`./pants\` script does not work with Pants <= 1.25.0 (and it also requires using \`pants.toml\`,
+rather than \`pants.ini\`). Instead, either upgrade your \`pants_version\` or use the version of the \`./pants\` script
+at https://raw.githubusercontent.com/Eric-Arellano/setup/0d445edef57cb89fd830db70810e38f050b0a268/pants."
+  fi
+  echo "${pants_version}"
+}
+
+function set_supported_python_versions {
+  local pants_version="$1"
+  local pants_major_version
+  local pants_minor_version
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  if [[ "${pants_major_version}" -eq 1 ]]; then
+    supported_python_versions_decimal=('3.6' '3.7' '3.8')
+    supported_python_versions_int=('36' '37' '38')
+    supported_message='3.6, 3.7, or 3.8'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -eq 0 ]]; then
+    supported_python_versions_decimal=('3.6' '3.7' '3.8')
+    supported_python_versions_int=('36' '37' '38')
+    supported_message='3.6, 3.7, or 3.8'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -eq 1 ]]; then
+    supported_python_versions_decimal=('3.7' '3.8' '3.6')
+    supported_python_versions_int=('37' '38' '36')
+    supported_message='3.7, 3.8, or 3.6 (deprecated)'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -lt 5 ]]; then
+    supported_python_versions_decimal=('3.8' '3.7')
+    supported_python_versions_int=('38' '37')
+    supported_message='3.7 or 3.8'
+  else
+    # We put 3.9 first because Apple Silicon only works properly with Python 3.9, even though it's possible to have
+    # older Pythons installed. This makes it more likely that Pants will work out-of-the-box.
+    supported_python_versions_decimal=('3.9' '3.8' '3.7')
+    supported_python_versions_int=('39' '38' '37')
+    supported_message='3.7, 3.8, or 3.9'
+  fi
+}
+
+function check_python_exe_compatible_version {
+  local python_exe="$1"
+  local major_minor_version
+  major_minor_version="$(get_python_major_minor_version "${python_exe}")"
+  for valid_version in "${supported_python_versions_int[@]}"; do
+    if [[ "${major_minor_version}" == "${valid_version}" ]]; then
+      echo "${python_exe}" && return 0
+    fi
+  done
+}
+
+function determine_default_python_exe {
+  for version in "${supported_python_versions_decimal[@]}" "3" ""; do
+    local interpreter_path
+    interpreter_path="$(command -v "python${version}")"
+    if [[ -z "${interpreter_path}" ]]; then
+      continue
+    fi
+    # Check if a version is shimmed by pyenv or asdf but not configured.
+    if ! "${interpreter_path}" --version >/dev/null 2>&1; then
+      continue
+    fi
+    if [[ -n "$(check_python_exe_compatible_version "${interpreter_path}")" ]]; then
+      echo "${interpreter_path}" && return 0
+    fi
+  done
+}
+
+function determine_python_exe {
+  local pants_version="$1"
+  set_supported_python_versions "${pants_version}"
+  local requirement_str="For \`pants_version = \"${pants_version}\"\`, Pants requires Python ${supported_message} to run."
+
+  local python_exe
+  if [[ "${PYTHON_BIN_NAME}" != 'unspecified' ]]; then
+    python_exe="$(get_exe_path_or_die "${PYTHON_BIN_NAME}")" || exit 1
+    if [[ -z "$(check_python_exe_compatible_version "${python_exe}")" ]]; then
+      die "Invalid Python interpreter version for ${python_exe}. ${requirement_str}"
+    fi
+  else
+    python_exe="$(determine_default_python_exe)"
+    if [[ -z "${python_exe}" ]]; then
+      die "No valid Python interpreter found. ${requirement_str} Please check that a valid interpreter is installed and on your \$PATH."
+    fi
+  fi
+  echo "${python_exe}"
+}
+
+function compute_sha256 {
+  local python="$1"
+  local path="$2"
+
+  "$python" <<EOF
+import hashlib
+
+hasher = hashlib.sha256()
+with open('${path}', 'rb') as fp:
+    buf = fp.read()
+    hasher.update(buf)
+print(hasher.hexdigest())
+EOF
+}
+
+# TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
+# functions.  Any tmp dir w/o a symlink pointing to it can go.
+
+function bootstrap_pex {
+  local python="$1"
+  local bootstrapped="${PANTS_BOOTSTRAP}/pex-${_PEX_VERSION}/pex"
+  if [[ ! -f "${bootstrapped}" ]]; then
+    (
+      green "Downloading the Pex PEX."
+      mkdir -p "${PANTS_BOOTSTRAP}"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      cd "${staging_dir}"
+      curl --proto "=https" \
+           --tlsv1.2 \
+           --silent \
+           --location \
+           --remote-name \
+           "${_PEX_URL}"
+      fingerprint="$(compute_sha256 "${python}" "pex")"
+      if [[ "${_PEX_EXPECTED_SHA256}" != "${fingerprint}" ]]; then
+        die "SHA256 of ${_PEX_URL} is not as expected. Aborting."
+      fi
+      green "SHA256 fingerprint of ${_PEX_URL} verified."
+      mkdir -p "$(dirname "${bootstrapped}")"
+      mv -f "${staging_dir}/pex" "${bootstrapped}"
+      rmdir "${staging_dir}"
+    ) 1>&2 || exit 1
+  fi
+  echo "${bootstrapped}"
+}
+
+function scrub_env_vars {
+  # Ensure the virtualenv PEX runs as shrink-wrapped.
+  # See: https://github.com/pantsbuild/setup/issues/105
+  if [[ -n "${!PEX_@}" ]]; then
+    warn "Scrubbing ${!PEX_@}"
+    unset "${!PEX_@}"
+  fi
+  # Also ensure pip doesn't think packages on PYTHONPATH
+  # are already installed.
+  if [ -n "${PYTHONPATH:-}" ]; then
+    warn "Scrubbing PYTHONPATH"
+    unset PYTHONPATH
+  fi
+}
+
+function bootstrap_virtualenv {
+  local python="$1"
+  local bootstrapped="${PANTS_BOOTSTRAP}/virtualenv-${VIRTUALENV_VERSION}/virtualenv.pex"
+  if [[ ! -f "${bootstrapped}" ]]; then
+    (
+      green "Creating the virtualenv PEX."
+      pex_path="$(bootstrap_pex "${python}")" || exit 1
+      mkdir -p "${PANTS_BOOTSTRAP}"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      cd "${staging_dir}"
+      echo "${VIRTUALENV_REQUIREMENTS}" > requirements.txt
+      (
+        scrub_env_vars
+        "${python}" "${pex_path}" -r requirements.txt -c virtualenv -o virtualenv.pex
+      )
+      mkdir -p "$(dirname "${bootstrapped}")"
+      mv -f "${staging_dir}/virtualenv.pex" "${bootstrapped}"
+      rm -rf "${staging_dir}"
+    ) 1>&2 || exit 1
+  fi
+  echo "${bootstrapped}"
+}
+
+function find_links_url {
+  local pants_version="$1"
+  local pants_sha="$2"
+  echo -n "https://binaries.pantsbuild.org/wheels/pantsbuild.pants/${pants_sha}/${pants_version/+/%2B}/index.html"
+}
+
+function get_version_for_sha {
+  local sha="$1"
+
+  # Retrieve the Pants version associated with this commit.
+  local pants_version
+  pants_version="$(curl --proto "=https" \
+                        --tlsv1.2 \
+                        --fail \
+                        --silent \
+                        --location \
+                        "https://raw.githubusercontent.com/pantsbuild/pants/${sha}/src/python/pants/VERSION")"
+
+  # Construct the version as the release version from src/python/pants/VERSION, plus the string `+gitXXXXXXXX`,
+  # where the XXXXXXXX is the first 8 characters of the SHA.
+  echo "${pants_version}+git${sha:0:8}"
+}
+
+function bootstrap_pants {
+  local pants_version="$1"
+  local python="$2"
+  local pants_sha="${3:-}"
+
+  local pants_requirement="pantsbuild.pants==${pants_version}"
+  local maybe_find_links
+  if [[ -z "${pants_sha}" ]]; then
+    maybe_find_links=""
+  else
+    maybe_find_links="--find-links=$(find_links_url "${pants_version}" "${pants_sha}")"
+   fi
+  local python_major_minor_version
+  python_major_minor_version="$(get_python_major_minor_version "${python}")"
+  local target_folder_name="${pants_version}_py${python_major_minor_version}"
+  local bootstrapped="${PANTS_BOOTSTRAP}/${target_folder_name}"
+
+  if [[ ! -d "${bootstrapped}" ]]; then
+    (
+      green "Bootstrapping Pants using ${python}"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      local virtualenv_path
+      virtualenv_path="$(bootstrap_virtualenv "${python}")" || exit 1
+      green "Installing ${pants_requirement} into a virtual environment at ${bootstrapped}"
+      (
+        scrub_env_vars
+        # shellcheck disable=SC2086
+        "${python}" "${virtualenv_path}" --quiet --no-download "${staging_dir}/install" && \
+        # Grab the latest pip, but don't advance setuptools past 58 which drops support for the
+        # `setup` kwarg `use_2to3` which Pants 1.x sdist dependencies (pystache) use.
+        "${staging_dir}/install/bin/pip" install --quiet -U pip "setuptools<58" && \
+        "${staging_dir}/install/bin/pip" install ${maybe_find_links} --quiet --progress-bar off "${pants_requirement}"
+      ) && \
+      ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \
+      mv "${staging_dir}/${target_folder_name}" "${bootstrapped}" && \
+      green "New virtual environment successfully created at ${bootstrapped}."
+    ) 1>&2 || exit 1
+  fi
+  echo "${bootstrapped}"
+}
+
+# Ensure we operate from the context of the ./pants buildroot.
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+pants_version="$(determine_pants_version)"
+python="$(determine_python_exe "${pants_version}")"
+pants_dir="$(bootstrap_pants "${pants_version}" "${python}" "${PANTS_SHA:-}")" || exit 1
+
+pants_python="${pants_dir}/bin/python"
+pants_binary="${pants_dir}/bin/pants"
+pants_extra_args=""
+if [[ -n "${PANTS_SHA:-}" ]]; then
+  pants_extra_args="${pants_extra_args} --python-repos-repos=$(find_links_url "$pants_version" "$PANTS_SHA")"
+fi
+
+# shellcheck disable=SC2086
+exec "${pants_python}" "${pants_binary}" ${pants_extra_args} \
+  --pants-bin-name="${PANTS_BIN_NAME}" --pants-version=${pants_version} "$@"

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,0 +1,6 @@
+[GLOBAL]
+dynamic_ui = false
+colors = true
+
+[auth]
+from_env_var = "TOOLCHAIN_AUTH_TOKEN"

--- a/pants.toml
+++ b/pants.toml
@@ -1,0 +1,44 @@
+[GLOBAL]
+pants_version = "2.12.0"
+backend_packages = [
+    "pants.backend.docker",
+    "pants.backend.docker.lint.hadolint",
+    "pants.backend.shell",
+    "pants.backend.shell.lint.shellcheck",
+    "pants.backend.shell.lint.shfmt"
+]
+
+pants_ignore = [
+    "!.buildkite/"
+]
+
+plugins = [
+  "toolchain.pants.plugin==0.20.0"
+]
+
+remote_cache_read = true
+remote_cache_write = true
+remote_store_address = "grpcs://cache.toolchain.com:443"
+remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
+
+[toolchain-setup]
+org = "grapl-security"
+repo = "hcl-formatter"
+
+[buildsense]
+enable = true
+
+# See https://www.pantsbuild.org/docs/anonymous-telemetry
+[anonymous-telemetry]
+enabled = true
+# Randomly generated with `uuidgen --random`
+repo_id = "3398d1b4-35d7-4864-a883-58aff0f11fe0"
+
+[shfmt]
+# Indent with 4 spaces
+# Indent switch cases
+# Redirect operators are followed by a space
+args = ["-i 4", "-ci", "-sr"]
+
+[test]
+output = "all"


### PR DESCRIPTION
As we increase usage of HCL across our codebases, we've run into a few
instances of files that are valid HCL (which are consumed just fine by
Consul, for example), but cannot (for whatever reason) be recognized
as valid HCL files by `packer fmt` and `packer lint`, which forms the
basis for the formatter and linter in this repository.

Rather than contorting our formatting and linting process in
these repositories, we can now specify an `--ignore` flag for our
formatter, allowing us to single out these offending files and, well,
ignore them.

As such, the main change here is in the `docker_entrypoint.sh`
script. Since this repository hasn't received any action since the
initial commit, however, we'll take the opportunity to upgrade the
build process to be more in line with our other
repositories.

Specifically:

- We use Pants to get easy access to `shellcheck`, `shfmt` and
  `hadolint`.
- We start using the code within this repository to lint and
  format the HCL here (rather than relying on published images; this
  serves as a very basic smoke test).
- We make use of Docker Compose v2, rather than v1.
- We spruce up the Makefile to mirror the ones in our other
  codebases.
- Finally, we upgrade the Packer image we base everything on to the
  current version `1.8.2`

Signed-off-by: Christopher Maier <chris@graplsecurity.com>